### PR TITLE
Add tests and fix error for getdelegate

### DIFF
--- a/src/PolyJuMP.jl
+++ b/src/PolyJuMP.jl
@@ -45,7 +45,7 @@ end
 function getdelegate(c::PolyConstraintRef, s::Symbol)
     delegate = getpolyconstr(c.m)[c.idx].delegate
     if isnull(delegate)
-        Base.warn("$(string(s)) value not defined for $(getname(v)). Check that the model was properly solved.")
+        error("$(string(s)) value not defined for constraint with index $c. Check that the model was properly solved.")
     end
     get(delegate)
 end

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -33,10 +33,14 @@ function cvarchecks(_error::Function, lowerbound::Number, upperbound::Number, st
         _error("Unrecognized keyword argument $kwarg")
     end
     if !isnan(start)
-        _error("Polynomial variable declaration does not support the form ... == value.")
+        _error("Polynomial variable declaration does not support the start keyword argument.")
     end
     if lowerbound != -Inf && upperbound != Inf
-        _error("Polynomial variable declaration does not support the form lb <= ... <= ub. Use ... >= 0 and separate constraints instead.")
+        if lowerbound == upperbound
+            _error("Polynomial variable declaration does not support the form ... == value.")
+        else
+            _error("Polynomial variable declaration does not support the form lb <= ... <= ub. Use ... >= 0 and separate constraints instead.")
+        end
     end
     if lowerbound != -Inf && lowerbound != 0
         _error("Polynomial variable declaration does not support the form ... >= lb with nonzero lb.")

--- a/test/variable.jl
+++ b/test/variable.jl
@@ -4,8 +4,9 @@
     @polyvar x y
     X = [x^2, y^2]
 
-    #@test_throws ErrorException @variable m p Poly(X) unknown_kw=1 # Fails on v0.5 on Travis
+    @test_throws ErrorException @variable m p Poly(X) unknown_kw=1
     @test_throws ErrorException @variable m p == 1 Poly(X)
+    @test_throws ErrorException @variable m p Poly(X) start=1
     @test_throws ErrorException @variable m 0 <= p <= 1 Poly(X)
     @test_throws ErrorException @variable m 0 >= p >= 1 Poly(X)
     @test_throws ErrorException @variable m p <= 0 Poly(X)


### PR DESCRIPTION
@chriscoey @joehuchette @rdeits Any objection to tag v0.2.0 once this PR is merged ? We need to tag v0.2.0 and not just v0.1.1 since it drops `@polyconstraint` and `@polyvariable` that have been deprecated in v0.1.0.