### PR TITLE
[WIP] Add polynomial basis

### DIFF
--- a/src/PolyJuMP.jl
+++ b/src/PolyJuMP.jl
@@ -6,62 +6,14 @@ using MultivariatePolynomials
 using MultivariateMoments
 using SemialgebraicSets
 using JuMP
-export getslack, setpolymodule!
-
-# Polynomial Constraint
-
-export ZeroPoly, NonNegPoly, NonNegPolyMatrix
-abstract type PolynomialSet end
-struct ZeroPoly <: PolynomialSet end
-struct NonNegPoly <: PolynomialSet end
-struct NonNegPolyMatrix <: PolynomialSet end
-
-struct PolyConstraint{PT, ST<:PolynomialSet} <: JuMP.AbstractConstraint
-    p::PT # typically either be a polynomial or a Matrix of polynomials
-    set::ST
-end
-const PolyConstraintRef = ConstraintRef{Model, PolyConstraint}
-
-# Responsible for getting slack and dual values
-abstract type ConstraintDelegate end
-
-function JuMP.addconstraint(m::Model, pc::PolyConstraint; domain::AbstractSemialgebraicSet=FullSpace(), kwargs...)
-    delegates = getdelegates(m)
-    delegate = addpolyconstraint!(m, pc.p, pc.set, domain; kwargs...)
-    push!(delegates, delegate)
-    m.internalModelLoaded = false
-    PolyConstraintRef(m, length(delegates))
-end
-
-getdelegate(c::PolyConstraintRef) = getdelegates(c.m)[c.idx]
-getslack(c::PolyConstraintRef) = getslack(getdelegate(c))
-JuMP.getdual(c::PolyConstraintRef) = getdual(getdelegate(c))
-
-# PolyJuMP Data
-type Data
-    # Delegates for polynomial constraints created
-    delegates::Vector{ConstraintDelegate}
-    # Default set for NonNegPoly
-    nonnegpolydefault::Nullable
-    # Default set for NonNegPolyMatrix
-    nonnegpolymatrixdefault::Nullable
-    function Data()
-        new(ConstraintDelegate[], nothing, nothing)
-    end
-end
-
-function getpolydata(m::JuMP.Model)
-    if !haskey(m.ext, :Poly)
-        m.ext[:Poly] = Data()
-    end
-    m.ext[:Poly]
-end
-getdelegates(m::JuMP.Model) = getpolydata(m).delegates
 
 include("basis.jl")
 
-include("macros.jl")
-include("default.jl")
+include("variable.jl")
+include("constraint.jl")
 include("default_methods.jl")
+
+include("data.jl")
+include("default.jl")
 
 end # module

--- a/src/PolyJuMP.jl
+++ b/src/PolyJuMP.jl
@@ -41,14 +41,12 @@ JuMP.getdual(c::PolyConstraintRef) = getdual(getdelegate(c))
 type Data
     # Delegates for polynomial constraints created
     delegates::Vector{ConstraintDelegate}
-    # Default set for Poly{true}
-    nonnegpolyvardefault::Nullable
     # Default set for NonNegPoly
     nonnegpolydefault::Nullable
     # Default set for NonNegPolyMatrix
     nonnegpolymatrixdefault::Nullable
     function Data()
-        new(ConstraintDelegate[], nothing, nothing, nothing)
+        new(ConstraintDelegate[], nothing, nothing)
     end
 end
 
@@ -59,6 +57,8 @@ function getpolydata(m::JuMP.Model)
     m.ext[:Poly]
 end
 getdelegates(m::JuMP.Model) = getpolydata(m).delegates
+
+include("basis.jl")
 
 include("macros.jl")
 include("default.jl")

--- a/src/basis.jl
+++ b/src/basis.jl
@@ -7,23 +7,23 @@ Polynomial basis of a subspace of the polynomials [Section~3.1.5, BPT12].
 
 [BPT12] Blekherman, G.; Parrilo, P. A. & Thomas, R. R.
 *Semidefinite Optimization and Convex Algebraic Geometry*.
-Society for Industrial and Applied Mathematics, 2012.
+Society for Industrial and Applied Mathematics, **2012**.
 """
 abstract type AbstractPolynomialBasis end
 
 """
-    struct FixedPolynomialBasis{PT<:MultivariatePolynomials.AbstractPolynomial, PV<:AbstractVector{PT}} <: AbstractPolynomialBasis
-        p::PV
+    struct FixedPolynomialBasis{PT<:MultivariatePolynomials.AbstractPolynomialLike, PV<:AbstractVector{PT}} <: AbstractPolynomialBasis
+        polynomials::PV
     end
 
-Polynomial basis with the polynomials of the vector `p`.
+Polynomial basis with the polynomials of the vector `polynomials`.
 For instance, `FixedPolynomialBasis([1, x, 2x^2-1, 4x^3-3x])` is the Chebyshev
 polynomial basis for cubic polynomials in the variable `x`.
 """
 struct FixedPolynomialBasis{PT<:MultivariatePolynomials.AbstractPolynomialLike, PV<:AbstractVector{PT}} <: AbstractPolynomialBasis
-    p::PV
+    polynomials::PV
 end
-FixedPolynomialBasis(p::PV) where {PT<:MultivariatePolynomials.AbstractPolynomialLike, PV<:AbstractVector{PT}} = FixedPolynomialBasis{PT, PV}(p)
+FixedPolynomialBasis(polynomials::PV) where {PT<:MultivariatePolynomials.AbstractPolynomialLike, PV<:AbstractVector{PT}} = FixedPolynomialBasis{PT, PV}(polynomials)
 
 function MultivariatePolynomials.polynomialtype(mb::FixedPolynomialBasis{PT}, T::Type) where PT
     C = MultivariatePolynomials.coefficienttype(PT)
@@ -31,24 +31,58 @@ function MultivariatePolynomials.polynomialtype(mb::FixedPolynomialBasis{PT}, T:
     MultivariatePolynomials.polynomialtype(PT, U)
 end
 function MultivariatePolynomials.polynomial(f::Function, fpb::FixedPolynomialBasis)
-    sum(ip -> f(ip[1]) * ip[2], enumerate(fpb.p))
+    sum(ip -> f(ip[1]) * ip[2], enumerate(fpb.polynomials))
 end
 
 """
     struct MonomialBasis{MT<:MultivariatePolynomials.AbstractMonomial, MV<:AbstractVector{MT}} <: AbstractPolynomialBasis
-        x::MV
+        monomials::MV
     end
 
-Monomial basis with the monomials of the vector `x`.
+Monomial basis with the monomials of the vector `monomials`.
 For instance, `MonomialBasis([1, x, y, x^2, x*y, y^2])` is the monomial basis
 for the subspace of quadratic polynomials in the variables `x`, `y`.
 """
 struct MonomialBasis{MT<:MultivariatePolynomials.AbstractMonomial, MV<:AbstractVector{MT}} <: AbstractPolynomialBasis
-    x::MV
+    monomials::MV
 end
-MonomialBasis(x::AbstractVector{MT}) where {MT<:MultivariatePolynomials.AbstractMonomial} = MonomialBasis{MT, typeof(x)}(x)
-MonomialBasis(x) = MonomialBasis(monovec(x))
+MonomialBasis(monomials::AbstractVector{MT}) where {MT<:MultivariatePolynomials.AbstractMonomial} = MonomialBasis{MT, typeof(monomials)}(monomials)
+MonomialBasis(monomials) = MonomialBasis(monovec(monomials))
 
 MultivariatePolynomials.polynomialtype(mb::MonomialBasis{MT}, T::Type) where MT = MultivariatePolynomials.polynomialtype(MT, T)
-MultivariatePolynomials.polynomial(f::Function, mb::MonomialBasis) = polynomial(f, mb.x)
+MultivariatePolynomials.polynomial(f::Function, mb::MonomialBasis) = polynomial(f, mb.monomials)
 MultivariatePolynomials.coefficients(p, ::Type{<:MonomialBasis}) = coefficients(p)
+
+"""
+    struct ScaledMonomialBasis{MT<:MultivariatePolynomials.AbstractMonomial, MV<:AbstractVector{MT}} <: AbstractPolynomialBasis
+        monomials::MV
+    end
+
+*Scaled monomial basis* (see [Section 3.1.5, BPT12]) with the monomials of the vector `monomials`.
+Given a monomial ``x^\\alpha = x_1^{\\alpha_1} \\cdots x_n^{\\alpha_n}`` of degree ``d = \\sum_{i=1}^n \\alpha_i``,
+the corresponding polynomial of the basis is
+```math
+{d \\choose \\alpha}^{\\frac{1}{2}} x^{\\alpha} \\quad \\text{ where } \\quad
+{d \\choose \\alpha} = \\frac{d!}{\\alpha_1! \\alpha_2! \\cdots \\alpha_n!}.
+```
+
+For instance, create a polynomial with the basis ``[xy^2, xy]`` creates the polynomial
+``\\sqrt{3} a xy^2 + \\sqrt{2} b xy`` where `a` and `b` are new JuMP decision variables.
+Constraining the polynomial ``axy^2 + bxy`` to be zero with the scaled monomial basis constrains
+`a/√3` and `b/√2` to be zero.
+
+[BPT12] Blekherman, G.; Parrilo, P. A. & Thomas, R. R.
+*Semidefinite Optimization and Convex Algebraic Geometry*.
+Society for Industrial and Applied Mathematics, **2012**.
+"""
+struct ScaledMonomialBasis{MT<:MultivariatePolynomials.AbstractMonomial, MV<:AbstractVector{MT}} <: AbstractPolynomialBasis
+    monomials::MV
+end
+ScaledMonomialBasis(monomials::AbstractVector{MT}) where {MT<:MultivariatePolynomials.AbstractMonomial} = ScaledMonomialBasis{MT, typeof(monomials)}(monomials)
+ScaledMonomialBasis(monomials) = ScaledMonomialBasis(monovec(monomials))
+
+MultivariatePolynomials.polynomialtype(mb::ScaledMonomialBasis{MT}, T::Type) where MT = MultivariatePolynomials.polynomialtype(MT, promote_type(T, Float64))
+scaling(m::MultivariatePolynomials.AbstractMonomial) = √(factorial(degree(m)) / prod(factorial, exponents(m)))
+MultivariatePolynomials.polynomial(f::Function, mb::ScaledMonomialBasis) = polynomial(i -> scaling(mb.monomials[i]) * f(i), mb.monomials)
+unscale_coef(t::MultivariatePolynomials.AbstractTerm) = coefficient(t) / scaling(monomial(t))
+MultivariatePolynomials.coefficients(p, ::Type{<:ScaledMonomialBasis}) = unscale_coef.(terms(p))

--- a/src/basis.jl
+++ b/src/basis.jl
@@ -1,0 +1,49 @@
+"""
+    abstract type AbstractPolynomialBasis end
+
+Polynomial basis of a subspace of the polynomials [Section~3.1.5, BPT12].
+
+[BPT12] Blekherman, G.; Parrilo, P. A. & Thomas, R. R.
+*Semidefinite Optimization and Convex Algebraic Geometry*.
+Society for Industrial and Applied Mathematics, 2012.
+"""
+abstract type AbstractPolynomialBasis end
+
+"""
+    struct FixedPolynomialBasis{PT<:MultivariatePolynomials.AbstractPolynomial, PV<:AbstractVector{PT}} <: AbstractPolynomialBasis
+        p::PV
+    end
+
+Polynomial basis with the polynomials of the vector `p`.
+For instance, `FixedPolynomialBasis([1, x, 2x^2-1, 4x^3-3x])` is the Chebyshev
+polynomial basis for cubic polynomials in the variable `x`.
+"""
+struct FixedPolynomialBasis{PT<:MultivariatePolynomials.AbstractPolynomial, PV<:AbstractVector{PT}} <: AbstractPolynomialBasis
+    p::PV
+end
+
+function MultivariatePolynomials.polynomialtype(mb::FixedPolynomialBasis{PT}, T::Type) where PT
+    C = MultivariatePolynomials.coefficienttype(PT)
+    U = typeof(zero(C) * zero(T) + zero(C) * zero(T))
+    MultivariatePolynomials.polynomialtype(PT, U)
+end
+
+"""
+    struct MonomialBasis{MT<:MultivariatePolynomials.AbstractMonomial, MV<:AbstractVector{MT}} <: AbstractPolynomialBasis
+        x::MV
+    end
+
+Monomial basis with the monomials of the vector `x`.
+For instance, `MonomialBasis([1, x, y, x^2, x*y, y^2])` is the monomial basis
+for the subspace of quadratic polynomials in the variables `x`, `y`.
+"""
+struct MonomialBasis{MT<:MultivariatePolynomials.AbstractMonomial, MV<:AbstractVector{MT}} <: AbstractPolynomialBasis
+    x::MV
+end
+MonomialBasis(x::AbstractVector{MT}) where {MT<:MultivariatePolynomials.AbstractMonomial} = MonomialBasis{MT, typeof(x)}(x)
+MonomialBasis(x) = MonomialBasis(monovec(x))
+
+MultivariatePolynomials.polynomialtype(mb::MonomialBasis{MT}, T::Type) where MT = MultivariatePolynomials.polynomialtype(MT, T)
+MultivariatePolynomials.polynomial(f::Function, mb::MonomialBasis) = polynomial(f, mb.x)
+
+abstract type AbstractMeasureBasis end

--- a/src/basis.jl
+++ b/src/basis.jl
@@ -1,3 +1,5 @@
+export FixedPolynomialBasis, MonomialBasis
+
 """
     abstract type AbstractPolynomialBasis end
 
@@ -21,6 +23,7 @@ polynomial basis for cubic polynomials in the variable `x`.
 struct FixedPolynomialBasis{PT<:MultivariatePolynomials.AbstractPolynomial, PV<:AbstractVector{PT}} <: AbstractPolynomialBasis
     p::PV
 end
+FixedPolynomialBasis(p::PV) where {PT<:MultivariatePolynomials.AbstractPolynomial, PV<:AbstractVector{PT}} = FixedPolynomialBasis{PT, PV}(p)
 
 function MultivariatePolynomials.polynomialtype(mb::FixedPolynomialBasis{PT}, T::Type) where PT
     C = MultivariatePolynomials.coefficienttype(PT)
@@ -45,5 +48,4 @@ MonomialBasis(x) = MonomialBasis(monovec(x))
 
 MultivariatePolynomials.polynomialtype(mb::MonomialBasis{MT}, T::Type) where MT = MultivariatePolynomials.polynomialtype(MT, T)
 MultivariatePolynomials.polynomial(f::Function, mb::MonomialBasis) = polynomial(f, mb.x)
-
-abstract type AbstractMeasureBasis end
+MultivariatePolynomials.coefficients(p, ::Type{<:MonomialBasis}) = coefficients(p)

--- a/src/basis.jl
+++ b/src/basis.jl
@@ -20,15 +20,18 @@ Polynomial basis with the polynomials of the vector `p`.
 For instance, `FixedPolynomialBasis([1, x, 2x^2-1, 4x^3-3x])` is the Chebyshev
 polynomial basis for cubic polynomials in the variable `x`.
 """
-struct FixedPolynomialBasis{PT<:MultivariatePolynomials.AbstractPolynomial, PV<:AbstractVector{PT}} <: AbstractPolynomialBasis
+struct FixedPolynomialBasis{PT<:MultivariatePolynomials.AbstractPolynomialLike, PV<:AbstractVector{PT}} <: AbstractPolynomialBasis
     p::PV
 end
-FixedPolynomialBasis(p::PV) where {PT<:MultivariatePolynomials.AbstractPolynomial, PV<:AbstractVector{PT}} = FixedPolynomialBasis{PT, PV}(p)
+FixedPolynomialBasis(p::PV) where {PT<:MultivariatePolynomials.AbstractPolynomialLike, PV<:AbstractVector{PT}} = FixedPolynomialBasis{PT, PV}(p)
 
 function MultivariatePolynomials.polynomialtype(mb::FixedPolynomialBasis{PT}, T::Type) where PT
     C = MultivariatePolynomials.coefficienttype(PT)
     U = typeof(zero(C) * zero(T) + zero(C) * zero(T))
     MultivariatePolynomials.polynomialtype(PT, U)
+end
+function MultivariatePolynomials.polynomial(f::Function, fpb::FixedPolynomialBasis)
+    sum(ip -> f(ip[1]) * ip[2], enumerate(fpb.p))
 end
 
 """

--- a/src/constraint.jl
+++ b/src/constraint.jl
@@ -2,18 +2,12 @@ export ZeroPoly, NonNegPoly, NonNegPolyMatrix
 export getslack
 
 abstract type PolynomialSet end
-struct ZeroPoly{B<:AbstractPolynomialBasis} <: PolynomialSet
-    basis::Type{B}
-end
-ZeroPoly() = ZeroPoly(MonomialBasis)
-struct NonNegPoly{B<:AbstractPolynomialBasis} <: PolynomialSet
-    basis::Type{B}
-end
-NonNegPoly() = NonNegPoly(MonomialBasis)
-struct NonNegPolyMatrix{B<:AbstractPolynomialBasis} <: PolynomialSet
-    basis::Type{B}
-end
-NonNegPolyMatrix() = NonNegPolyMatrix(MonomialBasis)
+struct ZeroPoly <: PolynomialSet end
+ZeroPoly() = ZeroPoly()
+struct NonNegPoly <: PolynomialSet end
+NonNegPoly() = NonNegPoly()
+struct NonNegPolyMatrix <: PolynomialSet end
+NonNegPolyMatrix() = NonNegPolyMatrix()
 
 struct PolyConstraint{PT, ST<:PolynomialSet} <: JuMP.AbstractConstraint
     p::PT # typically either be a polynomial or a Matrix of polynomials
@@ -24,9 +18,9 @@ const PolyConstraintRef = ConstraintRef{Model, PolyConstraint}
 # Responsible for getting slack and dual values
 abstract type ConstraintDelegate end
 
-function JuMP.addconstraint(m::Model, pc::PolyConstraint; domain::AbstractSemialgebraicSet=FullSpace(), kwargs...)
+function JuMP.addconstraint(m::Model, pc::PolyConstraint; domain::AbstractSemialgebraicSet=FullSpace(), basis=MonomialBasis, kwargs...)
     delegates = getdelegates(m)
-    delegate = addpolyconstraint!(m, pc.p, pc.set, domain; kwargs...)
+    delegate = addpolyconstraint!(m, pc.p, pc.set, domain, basis; kwargs...)
     push!(delegates, delegate)
     m.internalModelLoaded = false
     PolyConstraintRef(m, length(delegates))

--- a/src/constraint.jl
+++ b/src/constraint.jl
@@ -2,9 +2,18 @@ export ZeroPoly, NonNegPoly, NonNegPolyMatrix
 export getslack
 
 abstract type PolynomialSet end
-struct ZeroPoly{B<:AbstractPolynomialBasis} <: PolynomialSet end
-struct NonNegPoly <: PolynomialSet end
-struct NonNegPolyMatrix <: PolynomialSet end
+struct ZeroPoly{B<:AbstractPolynomialBasis} <: PolynomialSet
+    basis::Type{B}
+end
+ZeroPoly() = ZeroPoly(MonomialBasis)
+struct NonNegPoly{B<:AbstractPolynomialBasis} <: PolynomialSet
+    basis::Type{B}
+end
+NonNegPoly() = NonNegPoly(MonomialBasis)
+struct NonNegPolyMatrix{B<:AbstractPolynomialBasis} <: PolynomialSet
+    basis::Type{B}
+end
+NonNegPolyMatrix() = NonNegPolyMatrix(MonomialBasis)
 
 struct PolyConstraint{PT, ST<:PolynomialSet} <: JuMP.AbstractConstraint
     p::PT # typically either be a polynomial or a Matrix of polynomials

--- a/src/constraint.jl
+++ b/src/constraint.jl
@@ -1,0 +1,41 @@
+export ZeroPoly, NonNegPoly, NonNegPolyMatrix
+export getslack
+
+abstract type PolynomialSet end
+struct ZeroPoly{B<:AbstractPolynomialBasis} <: PolynomialSet end
+struct NonNegPoly <: PolynomialSet end
+struct NonNegPolyMatrix <: PolynomialSet end
+
+struct PolyConstraint{PT, ST<:PolynomialSet} <: JuMP.AbstractConstraint
+    p::PT # typically either be a polynomial or a Matrix of polynomials
+    set::ST
+end
+const PolyConstraintRef = ConstraintRef{Model, PolyConstraint}
+
+# Responsible for getting slack and dual values
+abstract type ConstraintDelegate end
+
+function JuMP.addconstraint(m::Model, pc::PolyConstraint; domain::AbstractSemialgebraicSet=FullSpace(), kwargs...)
+    delegates = getdelegates(m)
+    delegate = addpolyconstraint!(m, pc.p, pc.set, domain; kwargs...)
+    push!(delegates, delegate)
+    m.internalModelLoaded = false
+    PolyConstraintRef(m, length(delegates))
+end
+
+getdelegate(c::PolyConstraintRef) = getdelegates(c.m)[c.idx]
+getslack(c::PolyConstraintRef) = getslack(getdelegate(c))
+JuMP.getdual(c::PolyConstraintRef) = getdual(getdelegate(c))
+
+# Macro
+function JuMP.constructconstraint!(p::AbstractPolynomialLike, sense::Symbol)
+    JuMP.constructconstraint!(sense == :(<=) ? -p : p, sense == :(==) ? ZeroPoly() : NonNegPoly())
+end
+
+function JuMP.constructconstraint!(p::Union{AbstractPolynomialLike, AbstractMatrix{<:AbstractPolynomialLike}}, s)
+    PolyConstraint(p, s)
+end
+# there is already a method for AbstractMatrix in PSDCone in JuMP so we need a more specific here to avoid ambiguity
+function JuMP.constructconstraint!(p::AbstractMatrix{<:AbstractPolynomialLike}, s::PSDCone)
+    PolyConstraint(p, NonNegPolyMatrix())
+end

--- a/src/constraint.jl
+++ b/src/constraint.jl
@@ -3,11 +3,8 @@ export getslack
 
 abstract type PolynomialSet end
 struct ZeroPoly <: PolynomialSet end
-ZeroPoly() = ZeroPoly()
 struct NonNegPoly <: PolynomialSet end
-NonNegPoly() = NonNegPoly()
 struct NonNegPolyMatrix <: PolynomialSet end
-NonNegPolyMatrix() = NonNegPolyMatrix()
 
 struct PolyConstraint{PT, ST<:PolynomialSet} <: JuMP.AbstractConstraint
     p::PT # typically either be a polynomial or a Matrix of polynomials

--- a/src/data.jl
+++ b/src/data.jl
@@ -1,0 +1,20 @@
+# PolyJuMP Data
+type Data
+    # Delegates for polynomial constraints created
+    delegates::Vector{ConstraintDelegate}
+    # Default set for NonNegPoly
+    nonnegpolydefault::Nullable
+    # Default set for NonNegPolyMatrix
+    nonnegpolymatrixdefault::Nullable
+    function Data()
+        new(ConstraintDelegate[], nothing, nothing)
+    end
+end
+
+function getpolydata(m::JuMP.Model)
+    if !haskey(m.ext, :Poly)
+        m.ext[:Poly] = Data()
+    end
+    m.ext[:Poly]
+end
+getdelegates(m::JuMP.Model) = getpolydata(m).delegates

--- a/src/default.jl
+++ b/src/default.jl
@@ -1,3 +1,5 @@
+export setpolymodule!
+
 setdefault!(m::JuMP.Model, S::Type, T::Type) = setdefault!(getpolydata(m), S, T)
 setdefault!(data::Data, ::Type{NonNegPoly}, S::Type) = data.nonnegpolydefault = S
 setdefault!(data::Data, ::Type{NonNegPolyMatrix}, S::Type) = data.nonnegpolymatrixdefault = S

--- a/src/default.jl
+++ b/src/default.jl
@@ -8,12 +8,9 @@ getdefault(m::JuMP.Model, s) = getdefault(getpolydata(m), s)
 
 # includes Poly but also custom types defined by other modules
 getdefault(data::Data, p) = p
-function getdefault(data::Data, s::Union{NonNegPoly, NonNegPolyMatrix})
-    S = getdefault(data, typeof(s))
-    S(s.basis)
-end
-getdefault(data::Data, ::Type{<:NonNegPoly}) = get_default(data.nonnegpolydefault)
-getdefault(data::Data, ::Type{<:NonNegPolyMatrix}) = get_default(data.nonnegpolymatrixdefault)
+getdefault(data::Data, s::Union{NonNegPoly, NonNegPolyMatrix}) = getdefault(data, typeof(s))()
+getdefault(data::Data, ::Type{NonNegPoly}) = get_default(data.nonnegpolydefault)
+getdefault(data::Data, ::Type{NonNegPolyMatrix}) = get_default(data.nonnegpolymatrixdefault)
 
 setpolymodule!(m::JuMP.Model, pm::Module) = setpolymodule!(getpolydata(m), pm)
 setpolymodule!(data::Data, pm::Module) = pm.setdefaults!(data)

--- a/src/default.jl
+++ b/src/default.jl
@@ -1,16 +1,11 @@
 setdefault!(m::JuMP.Model, S::Type, T::Type) = setdefault!(getpolydata(m), S, T)
-setdefault!(data::Data, ::Type{Poly{true}}, S::Type) = data.nonnegpolyvardefault = S
 setdefault!(data::Data, ::Type{NonNegPoly}, S::Type) = data.nonnegpolydefault = S
 setdefault!(data::Data, ::Type{NonNegPolyMatrix}, S::Type) = data.nonnegpolymatrixdefault = S
 
 getdefault(m::JuMP.Model, s) = getdefault(getpolydata(m), s)
 
-# includes Poly{false} but also custom types defined by other modules
+# includes Poly but also custom types defined by other modules
 getdefault(data::Data, p) = p
-getdefault(data::Data, p::Poly{true, MS}) where MS = getdefault(data, Poly{true}){MS}(p.x)
-getdefault(data::Data, ::Type{Poly{true}}) = get_default(data.nonnegpolyvardefault)
-
-# includes Poly{false} but also custom types defined by other modules
 getdefault(data::Data, s::Union{NonNegPoly, NonNegPolyMatrix}) = getdefault(data, typeof(s))()
 getdefault(data::Data, ::Type{NonNegPoly}) = get_default(data.nonnegpolydefault)
 getdefault(data::Data, ::Type{NonNegPolyMatrix}) = get_default(data.nonnegpolymatrixdefault)

--- a/src/default.jl
+++ b/src/default.jl
@@ -8,9 +8,12 @@ getdefault(m::JuMP.Model, s) = getdefault(getpolydata(m), s)
 
 # includes Poly but also custom types defined by other modules
 getdefault(data::Data, p) = p
-getdefault(data::Data, s::Union{NonNegPoly, NonNegPolyMatrix}) = getdefault(data, typeof(s))()
-getdefault(data::Data, ::Type{NonNegPoly}) = get_default(data.nonnegpolydefault)
-getdefault(data::Data, ::Type{NonNegPolyMatrix}) = get_default(data.nonnegpolymatrixdefault)
+function getdefault(data::Data, s::Union{NonNegPoly, NonNegPolyMatrix})
+    S = getdefault(data, typeof(s))
+    S(s.basis)
+end
+getdefault(data::Data, ::Type{<:NonNegPoly}) = get_default(data.nonnegpolydefault)
+getdefault(data::Data, ::Type{<:NonNegPolyMatrix}) = get_default(data.nonnegpolymatrixdefault)
 
 setpolymodule!(m::JuMP.Model, pm::Module) = setpolymodule!(getpolydata(m), pm)
 setpolymodule!(data::Data, pm::Module) = pm.setdefaults!(data)

--- a/src/default_methods.jl
+++ b/src/default_methods.jl
@@ -9,7 +9,7 @@ function createpoly(m::JuMP.Model, p::Poly, category::Symbol)
 end
 
 # NonNegPoly and NonNegPolyMatrix
-addpolyconstraint!(m::JuMP.Model, p, s::Union{NonNegPoly, NonNegPolyMatrix}, domain; kwargs...) = addpolyconstraint!(m, p, getdefault(m, s), domain; kwargs...)
+addpolyconstraint!(m::JuMP.Model, p, s::Union{NonNegPoly, NonNegPolyMatrix}, domain, basis; kwargs...) = addpolyconstraint!(m, p, getdefault(m, s), domain, basis; kwargs...)
 
 # ZeroPoly
 struct ZeroConstraint{MT <: AbstractMonomial, MVT <: AbstractVector{MT}, JC <: JuMP.AbstractConstraint} <: ConstraintDelegate

--- a/src/default_methods.jl
+++ b/src/default_methods.jl
@@ -1,18 +1,11 @@
 # Free polynomial
-JuMP.variabletype(m::JuMP.Model, p::Poly{false}) = polytype(m, p, p.x)
-polytype(m::JuMP.Model, ::Poly{false}, x::AbstractVector{MT}) where MT<:AbstractMonomial = MultivariatePolynomials.polynomialtype(MT, JuMP.Variable)
-
-# x should be sorted and without duplicates
-function _createpoly(m::JuMP.Model, ::Poly{false}, x::AbstractVector{<:AbstractMonomial}, category::Symbol)
-    polynomial((i) -> Variable(m, -Inf, Inf, category), x)
+JuMP.variabletype(m::JuMP.Model, p::Poly) = polytype(m, p, p.polynomial_basis)
+function polytype(m::JuMP.Model, ::Poly, pb::AbstractPolynomialBasis)
+    MultivariatePolynomials.polynomialtype(pb, JuMP.Variable)
 end
 
-function createpoly(m::JuMP.Model, p::Poly{false, :Gram}, category::Symbol)
-    _createpoly(m, p, monomials(sum(p.x)^2), category)
-end
-
-function createpoly(m::JuMP.Model, p::Union{Poly{false, :Default}, Poly{false, :Classic}}, category::Symbol)
-    _createpoly(m, p, p.x, category)
+function createpoly(m::JuMP.Model, p::Poly, category::Symbol)
+    polynomial(i -> Variable(m, -Inf, Inf, category), p.polynomial_basis)
 end
 
 # NonNegPoly and NonNegPolyMatrix

--- a/src/default_methods.jl
+++ b/src/default_methods.jl
@@ -22,14 +22,14 @@ end
 
 JuMP.getdual(c::ZeroConstraint) = measure(getdual.(c.zero_constraints), c.x)
 
-function addpolyconstraint!(m::JuMP.Model, p, s::ZeroPoly, domain::FullSpace)
-    constraints = JuMP.constructconstraint!.(coefficients(p, s.basis), :(==))
+function addpolyconstraint!(m::JuMP.Model, p, s::ZeroPoly, domain::FullSpace, basis)
+    constraints = JuMP.constructconstraint!.(coefficients(p, basis), :(==))
     zero_constraints = JuMP.addVectorizedConstraint(m, constraints)
     ZeroConstraint(zero_constraints, monomials(p))
 end
 
-function addpolyconstraint!(m::JuMP.Model, p, s::ZeroPoly, domain::AbstractAlgebraicSet)
-    addpolyconstraint!(m, rem(p, ideal(domain)), s, FullSpace())
+function addpolyconstraint!(m::JuMP.Model, p, s::ZeroPoly, domain::AbstractAlgebraicSet, basis)
+    addpolyconstraint!(m, rem(p, ideal(domain)), s, FullSpace(), basis)
 end
 
 struct ZeroConstraintWithDomain{DT<:ConstraintDelegate} <: ConstraintDelegate
@@ -37,8 +37,8 @@ struct ZeroConstraintWithDomain{DT<:ConstraintDelegate} <: ConstraintDelegate
     upper::DT
 end
 
-function addpolyconstraint!(m::JuMP.Model, p, s::ZeroPoly, domain::BasicSemialgebraicSet)
-    lower = addpolyconstraint!(m,  p, NonNegPoly(s.basis), domain)
-    upper = addpolyconstraint!(m, -p, NonNegPoly(s.basis), domain)
+function addpolyconstraint!(m::JuMP.Model, p, s::ZeroPoly, domain::BasicSemialgebraicSet, basis)
+    lower = addpolyconstraint!(m,  p, NonNegPoly(), domain, basis)
+    upper = addpolyconstraint!(m, -p, NonNegPoly(), domain, basis)
     ZeroConstraintWithDomain(lower, upper)
 end

--- a/src/default_methods.jl
+++ b/src/default_methods.jl
@@ -23,7 +23,7 @@ end
 JuMP.getdual(c::ZeroConstraint) = measure(getdual.(c.zero_constraints), c.x)
 
 function addpolyconstraint!(m::JuMP.Model, p, s::ZeroPoly, domain::FullSpace)
-    constraints = JuMP.constructconstraint!.(coefficients(p), :(==))
+    constraints = JuMP.constructconstraint!.(coefficients(p, s.basis), :(==))
     zero_constraints = JuMP.addVectorizedConstraint(m, constraints)
     ZeroConstraint(zero_constraints, monomials(p))
 end
@@ -38,7 +38,7 @@ struct ZeroConstraintWithDomain{DT<:ConstraintDelegate} <: ConstraintDelegate
 end
 
 function addpolyconstraint!(m::JuMP.Model, p, s::ZeroPoly, domain::BasicSemialgebraicSet)
-    lower = addpolyconstraint!(m,  p, NonNegPoly(), domain)
-    upper = addpolyconstraint!(m, -p, NonNegPoly(), domain)
+    lower = addpolyconstraint!(m,  p, NonNegPoly(s.basis), domain)
+    upper = addpolyconstraint!(m, -p, NonNegPoly(s.basis), domain)
     ZeroConstraintWithDomain(lower, upper)
 end

--- a/src/variable.jl
+++ b/src/variable.jl
@@ -21,6 +21,7 @@ struct Poly{PB<:AbstractPolynomialBasis} <: AbstractPoly
 end
 Poly(x::AbstractVector{<:MultivariatePolynomials.AbstractPolynomialLike}) = Poly(MonomialBasis(x))
 
+# Macro
 function cvarchecks(_error::Function, lowerbound::Number, upperbound::Number, start::Number; extra_kwargs...)
     for (kwarg, _) in extra_kwargs
         _error("Unrecognized keyword argument $kwarg")
@@ -52,16 +53,4 @@ function JuMP.constructvariable!(m::Model, p::AbstractPoly, _error::Function, lo
     cvarchecks(_error, lowerbound, upperbound, start; extra_kwargs...)
     _warnbounds(_error, p, lowerbound, upperbound)
     createpoly(m, getdefault(m, p), category == :Default ? :Cont : category)
-end
-
-function JuMP.constructconstraint!(p::AbstractPolynomialLike, sense::Symbol)
-    JuMP.constructconstraint!(sense == :(<=) ? -p : p, sense == :(==) ? ZeroPoly() : NonNegPoly())
-end
-
-function JuMP.constructconstraint!(p::Union{AbstractPolynomialLike, AbstractMatrix{<:AbstractPolynomialLike}}, s)
-    PolyConstraint(p, s)
-end
-# there is already a method for AbstractMatrix in PSDCone in JuMP so we need a more specific here to avoid ambiguity
-function JuMP.constructconstraint!(p::AbstractMatrix{<:AbstractPolynomialLike}, s::PSDCone)
-    PolyConstraint(p, NonNegPolyMatrix())
 end

--- a/test/polymodule.jl
+++ b/test/polymodule.jl
@@ -1,14 +1,11 @@
 @testset "PolyModule" begin
     m = Model()
     # Triggers the creation of polydata
-    @test isnull(PolyJuMP.getpolydata(m).nonnegpolyvardefault)
-    @test_throws ErrorException PolyJuMP.getdefault(m, Poly{true})
     @test isnull(PolyJuMP.getpolydata(m).nonnegpolydefault)
     @test_throws ErrorException PolyJuMP.getdefault(m, NonNegPoly)
     @test isnull(PolyJuMP.getpolydata(m).nonnegpolymatrixdefault)
     @test_throws ErrorException PolyJuMP.getdefault(m, NonNegPolyMatrix)
     setpolymodule!(m, TestPolyModule)
-    @test PolyJuMP.getdefault(m, Poly{true}) == TestPolyModule.TestPoly
     @test PolyJuMP.getdefault(m, NonNegPoly) == TestPolyModule.TestNonNegConstraint
     @test PolyJuMP.getdefault(m, NonNegPolyMatrix) == TestPolyModule.TestNonNegMatrixConstraint
     PolyJuMP.setdefault!(m, NonNegPolyMatrix, TestPolyModule.TestNonNegConstraint)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,38 +8,7 @@ using MultivariatePolynomials
 using DynamicPolynomials
 #using TypedPolynomials
 
-module TestPolyModule
-using JuMP
-using PolyJuMP
-using MultivariatePolynomials
-struct TestPoly{MS, MT<:MultivariatePolynomials.AbstractMonomial, MVT<:AbstractVector{MT}}
-    x::MVT
-end
-TestPoly{MS}(x::AbstractVector{MT}) where {MS, MT} = TestPoly{MS, MT, typeof(x)}(x)
-struct TestPolyVar{MS}
-    x
-    category::Symbol
-end
-JuMP.variabletype(m::JuMP.Model, p::TestPoly{MS}) where MS = TestPolyVar{MS}
-PolyJuMP.createpoly(m::JuMP.Model, p::TestPoly{MS}, category::Symbol) where MS = TestPolyVar{MS}(p.x, category)
-
-struct TestNonNegConstraint end
-struct TestNonNegMatrixConstraint end
-struct TestConstraint <: PolyJuMP.ConstraintDelegate
-    p
-    set
-    domain
-    kwargs
-end
-PolyJuMP.addpolyconstraint!(m::JuMP.Model, p, s::Union{TestNonNegConstraint, TestNonNegMatrixConstraint}, domain; kwargs...) = TestConstraint(p, s, domain, kwargs)
-
-function setdefaults!(data::PolyJuMP.Data)
-    PolyJuMP.setdefault!(data, PolyJuMP.Poly{true}, TestPoly)
-    PolyJuMP.setdefault!(data, PolyJuMP.NonNegPoly, TestNonNegConstraint)
-    PolyJuMP.setdefault!(data, PolyJuMP.NonNegPolyMatrix, TestNonNegMatrixConstraint)
-end
-
-end
+include("testpolymodule.jl")
 
 include("polymodule.jl")
 include("variable.jl")

--- a/test/testpolymodule.jl
+++ b/test/testpolymodule.jl
@@ -3,21 +3,16 @@ using JuMP
 using PolyJuMP
 using MultivariatePolynomials
 
-struct TestNonNegConstraint
-    basis
-end
-TestNonNegConstraint() = TestNonNegConstraint(MonomialBasis)
-struct TestNonNegMatrixConstraint
-    basis
-end
-TestNonNegMatrixConstraint() = TestNonNegMatrixConstraint(MonomialBasis)
+struct TestNonNegConstraint <: PolyJuMP.PolynomialSet end
+struct TestNonNegMatrixConstraint <: PolyJuMP.PolynomialSet end
 struct TestConstraint <: PolyJuMP.ConstraintDelegate
     p
     set
     domain
+    basis
     kwargs
 end
-PolyJuMP.addpolyconstraint!(m::JuMP.Model, p, s::Union{TestNonNegConstraint, TestNonNegMatrixConstraint}, domain; kwargs...) = TestConstraint(p, s, domain, kwargs)
+PolyJuMP.addpolyconstraint!(m::JuMP.Model, p, s::Union{TestNonNegConstraint, TestNonNegMatrixConstraint}, domain, basis; kwargs...) = TestConstraint(p, s, domain, basis, kwargs)
 
 function setdefaults!(data::PolyJuMP.Data)
     PolyJuMP.setdefault!(data, PolyJuMP.NonNegPoly, TestNonNegConstraint)

--- a/test/testpolymodule.jl
+++ b/test/testpolymodule.jl
@@ -1,0 +1,21 @@
+module TestPolyModule
+using JuMP
+using PolyJuMP
+using MultivariatePolynomials
+
+struct TestNonNegConstraint end
+struct TestNonNegMatrixConstraint end
+struct TestConstraint <: PolyJuMP.ConstraintDelegate
+    p
+    set
+    domain
+    kwargs
+end
+PolyJuMP.addpolyconstraint!(m::JuMP.Model, p, s::Union{TestNonNegConstraint, TestNonNegMatrixConstraint}, domain; kwargs...) = TestConstraint(p, s, domain, kwargs)
+
+function setdefaults!(data::PolyJuMP.Data)
+    PolyJuMP.setdefault!(data, PolyJuMP.NonNegPoly, TestNonNegConstraint)
+    PolyJuMP.setdefault!(data, PolyJuMP.NonNegPolyMatrix, TestNonNegMatrixConstraint)
+end
+
+end

--- a/test/testpolymodule.jl
+++ b/test/testpolymodule.jl
@@ -3,8 +3,14 @@ using JuMP
 using PolyJuMP
 using MultivariatePolynomials
 
-struct TestNonNegConstraint end
-struct TestNonNegMatrixConstraint end
+struct TestNonNegConstraint
+    basis
+end
+TestNonNegConstraint() = TestNonNegConstraint(MonomialBasis)
+struct TestNonNegMatrixConstraint
+    basis
+end
+TestNonNegMatrixConstraint() = TestNonNegMatrixConstraint(MonomialBasis)
 struct TestConstraint <: PolyJuMP.ConstraintDelegate
     p
     set

--- a/test/variable.jl
+++ b/test/variable.jl
@@ -15,27 +15,6 @@
     @test_throws ErrorException @variable m p >= 0 Poly(X)
     @test_throws ErrorException @variable(m, p3[2:3] >= 0, Poly(X))
 
-    function testvar(p::MultivariatePolynomials.AbstractPolynomial{JuMP.Variable}, category=:Cont)
-        @test all(α -> m.colCat[α.col] == category, coefficients(p))
-    end
-
-    @variable m p1[1:3] Poly(X)
-    @test isa(p1, Vector{<:MultivariatePolynomials.AbstractPolynomial{JuMP.Variable}})
-    testvar(p1[1])
-    @variable(m, p2, Poly(X), category=:Int)
-    testvar(p2, :Int)
-    @variable(m, p3[2:3], Poly(X))
-    @test isa(p3, JuMP.JuMPArray{<:MultivariatePolynomials.AbstractPolynomial{JuMP.Variable},1,Tuple{UnitRange{Int}}})
-    testvar(p3[2])
-    @variable(m, p4[i=2:3,j=i:4], Poly(X), category=:Bin)
-    testvar(p4[2,3], :Bin)
-end
-
-@testset "@variable macro with Poly: Default methods" begin
-    m = Model()
-    @polyvar x y
-    X = [x^2, y^2]
-
     function testvar(p, x, category=:Cont)
         @test isa(p, DynamicPolynomials.Polynomial{true,JuMP.Variable})
         @test p.x == x
@@ -47,6 +26,21 @@ end
     testvar(p1[1], X)
     @variable(m, p2, Poly(X), category=:Int)
     testvar(p2, X, :Int)
+    @variable(m, p3[2:3], Poly(X))
+    @test isa(p3, JuMP.JuMPArray{DynamicPolynomials.Polynomial{true,JuMP.Variable},1,Tuple{UnitRange{Int}}})
+    testvar(p3[2], X)
+    @variable(m, p4[i=2:3,j=i:4], Poly(X), category=:Bin)
+    testvar(p4[2,3], X, :Bin)
+
+    X = [x^2, y^2]
+    @variable m p5[1:3] Poly(X)
+    @test isa(p5, Vector{DynamicPolynomials.Polynomial{true,JuMP.Variable}})
+    testvar(p5[1], X)
+    @variable(m, p6, Poly(X), category=:Int)
+    testvar(p6, X, :Int)
+
+    @variable(m, p7, Poly(FixedPolynomialBasis([1 - x^2, x^2 + 2])), category=:Bin)
+    testvar(p7, monovec([x^2, 1]), :Bin)
 end
 
 @testset "getvalue function" begin

--- a/test/variable.jl
+++ b/test/variable.jl
@@ -13,37 +13,22 @@
     @test_throws ErrorException @variable m p >= 1 Poly(X)
     @test_throws ErrorException @variable m p == 1 Poly(X)
     @test_throws ErrorException @variable m p >= 0 Poly(X)
+    @test_throws ErrorException @variable(m, p3[2:3] >= 0, Poly(X))
 
-    function testvar(p::MultivariatePolynomials.AbstractPolynomial, nonnegative, monotype, category=:Cont)
-        @test !nonnegative
-    end
-    function testvar(p::TestPolyModule.TestPolyVar{MS}, nonnegative, monotype, category=:Cont) where MS
-        @test MS == monotype
-        @test p.x == monovec(X)
-        @test p.x[1] == x^2
-        @test p.x[2] == y^2
-        @test p.x[3] == x
-        @test p.x[4] == y
-        @test p.x[5] == 1
-        @test p.category == category
+    function testvar(p::MultivariatePolynomials.AbstractPolynomial{JuMP.Variable}, category=:Cont)
+        @test all(α -> m.colCat[α.col] == category, coefficients(p))
     end
 
-    @variable m p1[1:3] Poly{true}(X)
-    @test isa(p1, Vector{TestPolyModule.TestPolyVar{:Default}})
-    testvar(p1[1], true, :Default)
-    @variable(m, p2, Poly{false, :Classic}(X), category=:Int)
-    testvar(p2, false, :Classic, :Int)
-    @variable(m, p3, Poly{false, :Gram}(X))
-    testvar(p3, false, :Gram)
-    @variable m p4 >= 0 Poly{true}(X)
-    testvar(p4, true, :Default)
-    @variable(m, p5 >= 0, Poly{true, :Classic}(X))
-    testvar(p5, true, :Classic)
-    @variable(m, p6[2:3] >= 0, Poly{true, :Gram}(X))
-    @test isa(p6, JuMP.JuMPArray{TestPolyModule.TestPolyVar{:Gram},1,Tuple{UnitRange{Int}}})
-    testvar(p6[2], true, :Gram)
-    @variable(m, p7[i=2:3,j=i:4], Poly{true}(X), category=:Bin)
-    testvar(p7[2,3], true, :Default, :Bin)
+    @variable m p1[1:3] Poly(X)
+    @test isa(p1, Vector{<:MultivariatePolynomials.AbstractPolynomial{JuMP.Variable}})
+    testvar(p1[1])
+    @variable(m, p2, Poly(X), category=:Int)
+    testvar(p2, :Int)
+    @variable(m, p3[2:3], Poly(X))
+    @test isa(p3, JuMP.JuMPArray{<:MultivariatePolynomials.AbstractPolynomial{JuMP.Variable},1,Tuple{UnitRange{Int}}})
+    testvar(p3[2])
+    @variable(m, p4[i=2:3,j=i:4], Poly(X), category=:Bin)
+    testvar(p4[2,3], :Bin)
 end
 
 @testset "@variable macro with Poly: Default methods" begin
@@ -51,18 +36,17 @@ end
     @polyvar x y
     X = [x^2, y^2]
 
-    function testvar(p, nonnegative, monotype, x, category=:Cont)
+    function testvar(p, x, category=:Cont)
         @test isa(p, DynamicPolynomials.Polynomial{true,JuMP.Variable})
         @test p.x == x
+        @test all(α -> m.colCat[α.col] == category, coefficients(p))
     end
 
     @variable m p1[1:3] Poly(X)
     @test isa(p1, Vector{DynamicPolynomials.Polynomial{true,JuMP.Variable}})
-    testvar(p1[1], false, :Default, X)
-    @variable(m, p2, Poly{false, :Classic}(X), category=:Int)
-    testvar(p2, false, :Classic, X, :Int)
-    @variable(m, p3, Poly{false, :Gram}(X))
-    testvar(p3, false, :Gram, [x^4,x^2*y^2,y^4])
+    testvar(p1[1], X)
+    @variable(m, p2, Poly(X), category=:Int)
+    testvar(p2, X, :Int)
 end
 
 @testset "getvalue function" begin

--- a/test/variable.jl
+++ b/test/variable.jl
@@ -1,9 +1,8 @@
 @testset "@variable macro with Poly" begin
-    m = Model()
-    setpolymodule!(m, TestPolyModule)
     @polyvar x y
     X = [1, y, x^2, x, y^2]
 
+    m = Model()
     @test_throws ErrorException @variable m p Poly(X) unknown_kw=1
     @test_throws ErrorException @variable m p == 1 Poly(X)
     @test_throws ErrorException @variable m p Poly(X) start=1
@@ -15,32 +14,55 @@
     @test_throws ErrorException @variable m p >= 0 Poly(X)
     @test_throws ErrorException @variable(m, p3[2:3] >= 0, Poly(X))
 
-    function testvar(p, x, category=:Cont)
-        @test isa(p, DynamicPolynomials.Polynomial{true,JuMP.Variable})
+    function testvar(m, p, x, category=:Cont, vars=true)
+        @test isa(p, vars ? DynamicPolynomials.Polynomial{true,JuMP.Variable} : DynamicPolynomials.Polynomial{true,JuMP.AffExpr})
         @test p.x == x
-        @test all(α -> m.colCat[α.col] == category, coefficients(p))
+        if vars
+            @test all(α -> m.colCat[α.col] == category, coefficients(p))
+        else
+            @test all(α -> m.colCat[α.vars[1].col] == category, coefficients(p))
+        end
     end
 
-    @variable m p1[1:3] Poly(X)
-    @test isa(p1, Vector{DynamicPolynomials.Polynomial{true,JuMP.Variable}})
-    testvar(p1[1], X)
-    @variable(m, p2, Poly(X), category=:Int)
-    testvar(p2, X, :Int)
-    @variable(m, p3[2:3], Poly(X))
-    @test isa(p3, JuMP.JuMPArray{DynamicPolynomials.Polynomial{true,JuMP.Variable},1,Tuple{UnitRange{Int}}})
-    testvar(p3[2], X)
-    @variable(m, p4[i=2:3,j=i:4], Poly(X), category=:Bin)
-    testvar(p4[2,3], X, :Bin)
+    @testset "MonomialBasis" begin
+        m = Model()
+        @variable m p1[1:3] Poly(X)
+        @test isa(p1, Vector{DynamicPolynomials.Polynomial{true,JuMP.Variable}})
+        testvar(m, p1[1], X)
+        @variable(m, p2, Poly(X), category=:Int)
+        testvar(m, p2, X, :Int)
+        @variable(m, p3[2:3], Poly(X))
+        @test isa(p3, JuMP.JuMPArray{DynamicPolynomials.Polynomial{true,JuMP.Variable},1,Tuple{UnitRange{Int}}})
+        testvar(m, p3[2], X)
+        @variable(m, p4[i=2:3,j=i:4], Poly(X), category=:Bin)
+        testvar(m, p4[2,3], X, :Bin)
 
-    X = [x^2, y^2]
-    @variable m p5[1:3] Poly(X)
-    @test isa(p5, Vector{DynamicPolynomials.Polynomial{true,JuMP.Variable}})
-    testvar(p5[1], X)
-    @variable(m, p6, Poly(X), category=:Int)
-    testvar(p6, X, :Int)
+        X = [x^2, y^2]
+        @variable m p5[1:3] Poly(X)
+        @test isa(p5, Vector{DynamicPolynomials.Polynomial{true,JuMP.Variable}})
+        testvar(m, p5[1], X)
+        @variable(m, p6, Poly(X), category=:Int)
+        testvar(m, p6, X, :Int)
+    end
 
-    @variable(m, p7, Poly(FixedPolynomialBasis([1 - x^2, x^2 + 2])), category=:Bin)
-    testvar(p7, monovec([x^2, 1]), :Bin)
+    @testset "FixedPolynomialBasis" begin
+        m = Model()
+        @variable(m, p1, Poly(FixedPolynomialBasis([1 - x^2, x^2 + 2])), category=:Bin)
+        testvar(m, p1, monovec([x^2, 1]), :Bin, false)
+        @variable(m, p2[1:2], Poly(FixedPolynomialBasis([1 - x^2, x^2 + 2])))
+        testvar(m, p2[1], monovec([x^2, 1]), :Cont, false)
+        # Elements of the basis have type monomial
+        @variable(m, p3[2:3], Poly(FixedPolynomialBasis([x, x^2])))
+        testvar(m, p3[2], monovec([x^2, x]), :Cont, false)
+        # Elements of the basis have type term
+        @variable(m, p4[1:2], Poly(FixedPolynomialBasis([1, x, x^2])), category=:Bin)
+        testvar(m, p4[1], monovec([x^2, x, 1]), :Bin, false)
+        # Elements of the basis have type variable
+        @variable(m, p5[-1:1], Poly(FixedPolynomialBasis([x, y])), category=:Int)
+        testvar(m, p5[0], monovec([x, y]), :Int, false)
+        @variable(m, p6[-1:1], Poly(FixedPolynomialBasis([x])), category=:Int)
+        testvar(m, p6[0], monovec([x]), :Int, false)
+    end
 end
 
 @testset "getvalue function" begin


### PR DESCRIPTION
This PR add polynomial basis as discussed in #17 .

It also removes two first types arguments to the `Poly` struct. The first argument was used to specify that the polynomial variable was nonnegative and the second specifies the meaning of the monomials.
I don't know if anyone was using this feature but it was confusing and it would be even more confusing with polynomial basis.
The meaning of the monomial only makes sense in the sum of squares context and creating a nonnegative polynomial variable is also maybe sum of squares specific.
The user can still either use `Poly(X)` which is a polynomial with monomials `X` or `SOSPoly(x)` (defined in SumOfSquares.jl) which is an SOS polynomial with Gram monomials `X`.
With this PR, `X` can now also be a polynomial basis.

Closes #17