### PR TITLE
Implement printing of constraints

### DIFF
--- a/test/testpolymodule.jl
+++ b/test/testpolymodule.jl
@@ -19,6 +19,7 @@ struct NonNeg{BT <: PolyJuMP.AbstractPolynomialBasis,
 end
 struct TestNonNeg <: PolyJuMP.PolynomialSet end
 
+JuMP.reshape_set(::NonNeg, ::PolyJuMP.PolynomialShape) = TestNonNeg()
 function JuMP.moi_set(cone::TestNonNeg,
                       monos::AbstractVector{<:AbstractMonomial};
                       domain::AbstractSemialgebraicSet=FullSpace(),
@@ -29,33 +30,106 @@ end
 
 function JuMP.build_constraint(_error::Function, p::AbstractPolynomialLike,
                                s::TestNonNeg; kwargs...)
+    coefs = PolyJuMP.non_constant_coefficients(p)
     monos = monomials(p)
     set = JuMP.moi_set(s, monos; kwargs...)
-    return JuMP.build_constraint(_error, coefficients(p), set)
+    return JuMP.VectorConstraint(coefs, set, PolyJuMP.PolynomialShape(monos))
+end
+
+struct MatrixPolynomialShape{MT <: AbstractMonomial,
+                             MVT <: AbstractVector{MT}} <: JuMP.AbstractShape
+    side_dimension::Int
+    monomials::Matrix{MVT}
+end
+
+function JuMP.reshape_vector(x::Vector,
+                             shape::MatrixPolynomialShape{MT}) where {MT}
+    n = shape.side_dimension
+    p = Matrix{polynomialtype(MT, eltype(x))}(undef, n, n)
+    k = 0
+    for j in 1:n
+        for i in 1:n
+            m = length(shape.monomials[i, j])
+            p[i, j] = polynomial(x[k .+ (1:m)], shape.monomials[i, j])
+            k += m
+        end
+    end
+    @assert length(x) == k
+    return p
 end
 
 struct PosDefMatrix{BT <: PolyJuMP.AbstractPolynomialBasis,
                     DT <: SemialgebraicSets.AbstractSemialgebraicSet,
-                    VT <: MultivariatePolynomials.AbstractVariable,
                     MT <: MultivariatePolynomials.AbstractMonomial,
                     MVT <: AbstractVector{MT}} <: MOI.AbstractVectorSet
     basis::Type{BT}
     domain::DT
-    y::Vector{VT}
-    monomials::MVT
+    monomials::Matrix{MVT}
     kwargs
 end
 struct TestPosDefMatrix <: PolyJuMP.PolynomialSet end
+
+function JuMP.reshape_set(::PosDefMatrix, ::MatrixPolynomialShape)
+    return TestPosDefMatrix()
+end
+function JuMP.moi_set(::TestPosDefMatrix,
+                      monos::Matrix{<:AbstractVector{<:AbstractMonomial}};
+                      domain::AbstractSemialgebraicSet=FullSpace(),
+                      basis=MonomialBasis, kwargs...)
+    return PosDefMatrix(basis, domain, monos, kwargs)
+end
+
 function JuMP.build_constraint(_error::Function,
                                p::Matrix{<:AbstractPolynomialLike},
-                               s::TestPosDefMatrix;
-                               basis=PolyJuMP.MonomialBasis,
-                               domain=FullSpace(), kwargs...)
+                               s::TestPosDefMatrix; kwargs...)
     n = LinearAlgebra.checksquare(p)
-    y = [similarvariable(eltype(p), gensym()) for i in 1:n]
-    q = dot(y, p * y)
-    set = PosDefMatrix(basis, domain, y, monomials(q), kwargs)
-    return JuMP.build_constraint(_error, coefficients(q), set)
+    # TODO we should use `non_constant_coefficients_type` once it exists
+    coefs = coefficienttype(p[1, 1])[]
+    for j in 1:n
+        for i in 1:n
+            append!(coefs, coefficients(p[i, j]))
+        end
+    end
+    monos = monomials.(p)
+    set = JuMP.moi_set(s, monos; kwargs...)
+    return JuMP.VectorConstraint(coefs, set, MatrixPolynomialShape(n, monos))
+end
+
+# TODO the function in JuMP should not require the eltype to be
+#      `AbstractJuMPScalar` so that we don't have to define this
+# These methods are just copy-paste from JuMP/src/print.jl
+function JuMP.function_string(::Type{REPLMode},
+                              A::AbstractMatrix{<:AbstractPolynomialLike})
+    str = sprint(show, MIME"text/plain"(), A)
+    lines = split(str, '\n')
+    # We drop the first line with the signature "m×n Array{...}:"
+    lines = lines[2:end]
+    # We replace the first space by an opening `[`
+    lines[1] = '[' * lines[1][2:end]
+    for i in 1:length(lines)
+        lines[i] = lines[i] * (i == length(lines) ? ']' : ';')
+    end
+    return join(lines, '\n')
+end
+function JuMP.function_string(print_mode::Type{IJuliaMode},
+                              A::AbstractMatrix{<:AbstractPolynomialLike})
+    str = sprint(show, MIME"text/plain"(), A)
+    str = "\\begin{bmatrix}\n"
+    for i in 1:size(A, 1)
+        line = ""
+        for j in 1:size(A, 2)
+            if j != 1
+                line *= " & "
+            end
+            if A isa Symmetric && i > j
+                line *= "\\cdot"
+            else
+                line *= JuMP.function_string(print_mode, A[i, j])
+            end
+        end
+        str *= line * "\\\\\n"
+    end
+    return str * "\\end{bmatrix}"
 end
 
 


### PR DESCRIPTION
Here is a small example of the printing enabled by this PR:
```julia
julia> using JuMP

julia> model = Model()
A JuMP Model
Feasibility problem with:
Variables: 0
Model mode: AUTOMATIC
CachingOptimizer state: NO_OPTIMIZER
Solver name: No optimizer attached.

julia> @variable(model, a)
a

julia> using DynamicPolynomials

julia> @polyvar x[1:2]
(PolyVar{true}[x₁, x₂],)

julia> using PolyJuMP

julia> @constraint(model, a * sum(x) == 1)
(a)x₁ + (a)x₂ + (-1) ∈ PolyJuMP.ZeroPoly()

julia> model
A JuMP Model
Feasibility problem with:
Variable: 1
`Array{GenericAffExpr{Float64,VariableRef},1}`-in-`PolyJuMP.ZeroPolynomialSet{SemialgebraicSets.FullSpace,MonomialBasis,Monomial{true},MonomialVector{true}}`: 1 constraint
Model mode: AUTOMATIC
CachingOptimizer state: NO_OPTIMIZER
Solver name: No optimizer attached.
Names registered in the model: a

julia> print(model)
Feasibility
Subject to
 (a)x₁ + (a)x₂ + (-1) ∈ PolyJuMP.ZeroPoly()
```